### PR TITLE
[CI-COVERAGE]

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -63,6 +63,10 @@ jobs:
         env:
           gw_user_id: 'occidere'
           gw_es_endpoint: 'localhost:9200'
+          gw_tasks: 'followerWatchTask,repositoryWatchTask'
+          gw_line_bot_id: ${{ secrets.GW_LINE_BOT_ID }}
+          gw_line_channel_token: ${{ secrets.GW_LINE_CHANNEL_TOKEN }}
+          gw_github_api_token: ${{ secrets.GW_GITHUB_API_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: sbt coverage test coverageReport coveralls
 

--- a/src/main/scala/org/occidere/githubwatcher/GithubWatcher.scala
+++ b/src/main/scala/org/occidere/githubwatcher/GithubWatcher.scala
@@ -1,6 +1,7 @@
 package org.occidere.githubwatcher
 
 import org.occidere.githubwatcher.logger.GithubWatcherLogger
+import org.occidere.githubwatcher.service.ElasticService
 import org.occidere.githubwatcher.task.{FollowerWatchTask, GithubWatcherTask, RepositoryWatchTask}
 
 import scala.util.{Failure, Success, Try}
@@ -26,5 +27,5 @@ object GithubWatcher extends App with GithubWatcherTask with GithubWatcherLogger
       case task => logger.warn(s"Unsupported task: $task")
     }
 
-  sys.exit(0)
+  ElasticService.close()
 }

--- a/src/main/scala/org/occidere/githubwatcher/service/ElasticService.scala
+++ b/src/main/scala/org/occidere/githubwatcher/service/ElasticService.scala
@@ -57,4 +57,6 @@ object ElasticService extends GithubWatcherLogger {
         .fields(repoMap))
     ).refreshImmediately
   }.await
+
+  def close(): Unit = client.close()
 }

--- a/src/test/scala/org/occidere/githubwatcher/service/GithubApiServiceTest.scala
+++ b/src/test/scala/org/occidere/githubwatcher/service/GithubApiServiceTest.scala
@@ -49,7 +49,7 @@ class GithubApiServiceTest extends AnyFlatSpec with should.Matchers {
   }
 
   "getForkLogins" should "return nonNull Iterable of Strings" in {
-    val getForkLogins = githubApiService.getWatcherLogins("occidere", "MMDownloader")
+    val getForkLogins = githubApiService.getForkLogins("occidere", "MMDownloader")
 
     println(getForkLogins)
     getForkLogins.shouldNot(be(null))

--- a/src/test/scala/org/occidere/githubwatcher/service/LineMessengerServiceTest.scala
+++ b/src/test/scala/org/occidere/githubwatcher/service/LineMessengerServiceTest.scala
@@ -2,8 +2,11 @@ package org.occidere.githubwatcher.service
 
 import org.occidere.githubwatcher.util.MessageBuilderUtils
 import org.occidere.githubwatcher.vo.{FollowerDiff, Repository, RepositoryDiff}
+import org.scalatest.PrivateMethodTester
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
+
+import scala.util.{Success, Try}
 
 /**
  * @author occidere
@@ -11,7 +14,7 @@ import org.scalatest.matchers.should
  * @Github: https://github.com/occidere
  * @since 2020-08-31
  */
-class LineMessengerServiceTest extends AnyFlatSpec with should.Matchers {
+class LineMessengerServiceTest extends AnyFlatSpec with PrivateMethodTester with should.Matchers {
 
   "createRepositoryMessage" should "Contain at least 15 lines" in {
     val prevRepo = new Repository("1", "test1", "desc1") {
@@ -39,5 +42,36 @@ class LineMessengerServiceTest extends AnyFlatSpec with should.Matchers {
 
     println(followerMessage)
     followerMessage.split("\n").length should be >= 4
+  }
+
+  "sendMessageIfExist with token" should "be succeeded" in {
+    Try(LineMessengerService invokePrivate PrivateMethod('sendMessageIfExist)("test")) match {
+      case Success(_) => println("Test message send success")
+    }
+  }
+
+  "sendFollowerMessage with token" should "be succeeded" in {
+    Try(LineMessengerService.sendFollowerMessage(FollowerDiff(List("a", "b"), List("a", "c")))) match {
+      case Success(_) => println(s"Message send success")
+    }
+  }
+
+  "sendRepositoryMessage with token" should "be succeeded" in {
+    Try(LineMessengerService.sendRepositoryMessage(
+      RepositoryDiff(
+        new Repository("1", "test", "desc") {
+          stargazerLogins = List("a", "b")
+          forkLogins = List("a", "b")
+          watcherLogins = List("a", "b")
+        },
+        new Repository("1", "test", "desc") {
+          stargazerLogins = List("b", "c")
+          forkLogins = List("b", "c")
+          watcherLogins = List("b", "c")
+        }
+      ))
+    ) match {
+      case Success(_) => println(s"Message send success")
+    }
   }
 }

--- a/src/test/scala/org/occidere/githubwatcher/service/LineMessengerServiceTest.scala
+++ b/src/test/scala/org/occidere/githubwatcher/service/LineMessengerServiceTest.scala
@@ -1,7 +1,7 @@
 package org.occidere.githubwatcher.service
 
 import org.occidere.githubwatcher.util.MessageBuilderUtils
-import org.occidere.githubwatcher.vo.{Repository, RepositoryDiff}
+import org.occidere.githubwatcher.vo.{FollowerDiff, Repository, RepositoryDiff}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 
@@ -13,7 +13,7 @@ import org.scalatest.matchers.should
  */
 class LineMessengerServiceTest extends AnyFlatSpec with should.Matchers {
 
-  "Message formatting test" should "Always success" in {
+  "createRepositoryMessage" should "Contain at least 15 lines" in {
     val prevRepo = new Repository("1", "test1", "desc1") {
       stargazerLogins = List("a", "b")
       forkLogins = List("a", "b")
@@ -27,6 +27,17 @@ class LineMessengerServiceTest extends AnyFlatSpec with should.Matchers {
     }
 
     val msg = MessageBuilderUtils.createRepositoryMessage(RepositoryDiff(prevRepo, latestRepo))
+
     println(msg)
+    msg.split("\n").length should be >= 15
+  }
+
+  "createFollowerMessage" should "Contain at least 4 lines" in {
+    val followerDiff = FollowerDiff(List("a", "b"), List("a", "c"))
+
+    val followerMessage = MessageBuilderUtils.createFollowerMessage(followerDiff)
+
+    println(followerMessage)
+    followerMessage.split("\n").length should be >= 4
   }
 }

--- a/src/test/scala/org/occidere/githubwatcher/task/GithubWatcherTaskTest.scala
+++ b/src/test/scala/org/occidere/githubwatcher/task/GithubWatcherTaskTest.scala
@@ -1,0 +1,18 @@
+package org.occidere.githubwatcher.task
+
+import org.occidere.githubwatcher.GithubWatcher
+import org.scalatest.PrivateMethodTester
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+/**
+ * @author occidere
+ * @Blog: https://occidere.blog.me
+ * @Github: https://github.com/occidere
+ * @since 2020-09-09
+ */
+class GithubWatcherTaskTest extends AnyFlatSpec with PrivateMethodTester with should.Matchers {
+  "All tasks test" should "finished successfully" in {
+    GithubWatcher.main(Array())
+  }
+}

--- a/src/test/scala/org/occidere/githubwatcher/task/GithubWatcherTaskTest.scala
+++ b/src/test/scala/org/occidere/githubwatcher/task/GithubWatcherTaskTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.PrivateMethodTester
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 
+import scala.util.{Success, Try}
+
 /**
  * @author occidere
  * @Blog: https://occidere.blog.me
@@ -13,6 +15,8 @@ import org.scalatest.matchers.should
  */
 class GithubWatcherTaskTest extends AnyFlatSpec with PrivateMethodTester with should.Matchers {
   "All tasks test" should "finished successfully" in {
-    GithubWatcher.main(Array())
+    Try(GithubWatcher.main(Array())) match {
+      case Success(_) => println("All tasks success")
+    }
   }
 }

--- a/src/test/scala/org/occidere/githubwatcher/vo/DiffTest.scala
+++ b/src/test/scala/org/occidere/githubwatcher/vo/DiffTest.scala
@@ -16,7 +16,7 @@ class DiffTest extends AnyFlatSpec with should.Matchers {
     followerDiff.newFollowerLogins.length should be >= 1
     followerDiff.deletedFollowerLogins.length should be >= 1
     followerDiff.notChangedFollowerLogins.length should be >= 1
-    followerDiff.hasChanged shouldEqual(true)
+    followerDiff.hasChanged shouldEqual true
   }
 
   "Each elements of RepositoryDiff" should "have at least 1 element and marked as changed" in {
@@ -41,6 +41,8 @@ class DiffTest extends AnyFlatSpec with should.Matchers {
     repositoryDiff.delForkLogins.length should be >= 1
     repositoryDiff.delWatcherLogins.length should be >= 1
 
-    (repositoryDiff.hasNewChanged && repositoryDiff.hasDelChanged && repositoryDiff.hasChanged) shouldEqual(true)
+    repositoryDiff.hasNewChanged shouldEqual true
+    repositoryDiff.hasDelChanged shouldEqual true
+    repositoryDiff.hasChanged shouldEqual true
   }
 }

--- a/src/test/scala/org/occidere/githubwatcher/vo/DiffTest.scala
+++ b/src/test/scala/org/occidere/githubwatcher/vo/DiffTest.scala
@@ -1,0 +1,46 @@
+package org.occidere.githubwatcher.vo
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+/**
+ * @author occidere
+ * @Blog: https://occidere.blog.me
+ * @Github: https://github.com/occidere
+ * @since 2020-09-09
+ */
+class DiffTest extends AnyFlatSpec with should.Matchers {
+  "Elements of FollowerDiff" should "have at least 1 element and marked as changed" in {
+    val followerDiff = FollowerDiff(List("a", "b"), List("a", "c"))
+
+    followerDiff.newFollowerLogins.length should be >= 1
+    followerDiff.deletedFollowerLogins.length should be >= 1
+    followerDiff.notChangedFollowerLogins.length should be >= 1
+    followerDiff.hasChanged shouldEqual(true)
+  }
+
+  "Each elements of RepositoryDiff" should "have at least 1 element and marked as changed" in {
+    val repositoryDiff = RepositoryDiff(
+      new Repository("1", "test", "test") {
+        stargazerLogins = List("a", "b")
+        forkLogins = List("a", "b")
+        watcherLogins = List("a", "b")
+      },
+      new Repository("1", "test", "test") {
+        stargazerLogins = List("a", "c")
+        forkLogins = List("a", "c")
+        watcherLogins = List("a", "c")
+      }
+    )
+
+    repositoryDiff.newStargazerLogins.length should be >= 1
+    repositoryDiff.newForkLogins.length should be >= 1
+    repositoryDiff.newWatcherLogins.length should be >= 1
+
+    repositoryDiff.delStargazerLogins.length should be >= 1
+    repositoryDiff.delForkLogins.length should be >= 1
+    repositoryDiff.delWatcherLogins.length should be >= 1
+
+    (repositoryDiff.hasNewChanged && repositoryDiff.hasDelChanged && repositoryDiff.hasChanged) shouldEqual(true)
+  }
+}


### PR DESCRIPTION
# [CI-COVERAGE] Add more test code

## Related Issues
- https://github.com/occidere/GithubWatcher/issues/8

## Contents
- Add more test code
- Replace force exist in last of `GithubWatcher` to `ElasticService.close()`
- Add secrets env on github actions for test