### PR TITLE
[BE-ReactionWatchTask] Fix reaction change of new comments are not be notified

### DIFF
--- a/src/main/scala/org/occidere/githubwatcher/service/GithubApiService.scala
+++ b/src/main/scala/org/occidere/githubwatcher/service/GithubApiService.scala
@@ -25,7 +25,7 @@ object GithubApiService {
   def getReactionsOfIssuesCreatedByUser: List[Reaction] = getBodies("issues", Map("per_page" -> "100", "filter" -> "created", "state" -> "all"))
     .map(x => MAPPER.convertValue(x + ("originDataType" -> ISSUE.toString), classOf[Reaction]))
 
-  def getReactionsOfCommentsInRepository(login: String, repo: String): List[Reaction] = getBodies(s"repos/$login/$repo/issues/comments")
+  def getReactionsOfCommentsInRepository(repoOwnerLogin: String, repo: String)(login: String): List[Reaction] = getBodies(s"repos/$repoOwnerLogin/$repo/issues/comments")
     .map(x => MAPPER.convertValue(x + ("originDataType" -> COMMENT.toString), classOf[Reaction]))
     .filter(_.login == login)
 

--- a/src/main/scala/org/occidere/githubwatcher/task/ReactionWatchTask.scala
+++ b/src/main/scala/org/occidere/githubwatcher/task/ReactionWatchTask.scala
@@ -22,7 +22,7 @@ object ReactionWatchTask extends Task with GithubWatcherLogger {
 
     // Merge issues' reactions with fetched reactions from Repo
     val latestReactions = reactionsFromIssues.distinctBy(x => s"${x.repoOwnerLogin}/${x.repoName}".hashCode)
-      .flatMap(x => GithubApiService.getReactionsOfCommentsInRepository(x.repoOwnerLogin, x.repoName)) ++ reactionsFromIssues
+      .flatMap(x => GithubApiService.getReactionsOfCommentsInRepository(x.repoOwnerLogin, x.repoName)(userId)) ++ reactionsFromIssues
 
     // Data from DB (Elasticsearch)
     val prevReactions = ElasticService.findAllReactionsByLogin(userId).map(x => x.uniqueKey -> x).toMap

--- a/src/main/scala/org/occidere/githubwatcher/vo/ReactionDiff.scala
+++ b/src/main/scala/org/occidere/githubwatcher/vo/ReactionDiff.scala
@@ -7,14 +7,14 @@ package org.occidere.githubwatcher.vo
  * @since 2020-09-23
  */
 case class ReactionDiff(prevReaction: Reaction, latestReaction: Reaction) {
-  val thumbUpDelta: Int = prevReaction.thumbUp - latestReaction.thumbUp
-  val thumbDownDelta: Int = prevReaction.thumbDown - latestReaction.thumbDown
-  val laughDelta: Int = prevReaction.laugh - latestReaction.laugh
-  val hoorayDelta: Int = prevReaction.hooray - latestReaction.hooray
-  val heartDelta: Int = prevReaction.heart - latestReaction.heart
-  val rocketDelta: Int = prevReaction.rocket - latestReaction.rocket
-  val eyesDelta: Int = prevReaction.eyes - latestReaction.eyes
-  val confusedDelta: Int = prevReaction.confused - latestReaction.confused
+  val thumbUpDelta: Int = latestReaction.thumbUp - prevReaction.thumbUp
+  val thumbDownDelta: Int = latestReaction.thumbDown - prevReaction.thumbDown
+  val laughDelta: Int = latestReaction.laugh - prevReaction.laugh
+  val hoorayDelta: Int = latestReaction.hooray - prevReaction.hooray
+  val heartDelta: Int = latestReaction.heart - prevReaction.heart
+  val rocketDelta: Int = latestReaction.rocket - prevReaction.rocket
+  val eyesDelta: Int = latestReaction.eyes - prevReaction.eyes
+  val confusedDelta: Int = latestReaction.confused - prevReaction.confused
 
   val hasChanged: Boolean = thumbUpDelta != 0 || thumbDownDelta != 0 || laughDelta != 0 ||
     hoorayDelta != 0 || heartDelta != 0 || rocketDelta != 0 || eyesDelta != 0 || confusedDelta != 0

--- a/src/test/scala/org/occidere/githubwatcher/service/GithubApiServiceTest.scala
+++ b/src/test/scala/org/occidere/githubwatcher/service/GithubApiServiceTest.scala
@@ -65,7 +65,7 @@ class GithubApiServiceTest extends AnyFlatSpec with PrivateMethodTester with sho
   }
 
   "getReactionsOfCommentsInRepository" should "return nonNull List of Reactions" in {
-    val reactions = githubApiService.getReactionsOfCommentsInRepository("YoungStudyShopping", "leetcode_study")
+    val reactions = githubApiService.getReactionsOfCommentsInRepository("YoungStudyShopping", "leetcode_study")("occidere")
 
     println(reactions.size)
     println(reactions.find(_.totalCount > 0).orNull)


### PR DESCRIPTION
# Fix reaction change of new comments are not be notified

## Related Issues
- https://github.com/occidere/GithubWatcher/issues/15